### PR TITLE
[packaging] Pull in libcrypt for crypt function.

### DIFF
--- a/rpm/lua-posix.spec
+++ b/rpm/lua-posix.spec
@@ -13,6 +13,7 @@ Source0:        https://github.com/luaposix/luaposix/archive/v%{version}/lua-pos
 BuildRequires:  gcc
 BuildRequires:  lua-devel
 BuildRequires:  lua
+BuildRequires:  pkgconfig(libcrypt)
 
 
 %description


### PR DESCRIPTION
lua-posix depends on pkconfig(libcrypt) for the crypt function but it was
not included. This makes the build fail when pkconfig(libcrypt) is not bundled in the glib-devel package.

Signed-off-by: Björn Bidar <bjorn.bidar@jolla.com>